### PR TITLE
fixed divide by zero error

### DIFF
--- a/script.js
+++ b/script.js
@@ -33,16 +33,41 @@ function erase() {
 
 function calculate() {
     if (operator === "+") {
-        number = storedNumber + number;
+        if (isNaN(storedNumber)) {
+            number = "Err: Str";
+        }
+        else {
+            number = storedNumber + number;
+        }
     }
     else if (operator === "-") {
-        number = storedNumber - number;
+        if (isNaN(storedNumber)) {
+            number = "Err: Str";
+        }
+        else {
+            number = storedNumber - number;
+        }
     }
     else if (operator === "*") {
-        number = storedNumber * number;
+        if (isNaN(storedNumber)) {
+            number = "Err: Str";
+        }
+        else {
+            number = storedNumber * number;
+        }
     }
     else if (operator === "/") {
-        number = storedNumber / number;
+        if (number === 0) {
+            number = "Err: /0"
+        } 
+        else {
+            if (isNaN(storedNumber)) {
+                number = "Err: Str";
+            }
+            else {
+                number = storedNumber / number;
+            }
+        }
     }
     newNumber = true;
     operator = "";


### PR DESCRIPTION
This PR adds a specific error message when the user attempts to divide by zero, and another when they try to do a mathematical operation on the error message.